### PR TITLE
typing: fix typing issues in utils

### DIFF
--- a/monty/exts/info/docs/_html.py
+++ b/monty/exts/info/docs/_html.py
@@ -99,7 +99,7 @@ def _class_filter_factory(class_names: Iterable[str]) -> Callable[[Tag], bool]:
     return match_tag
 
 
-def get_general_description(start_element: Tag) -> List[Union[Tag, NavigableString]]:
+def get_general_description(start_element: PageElement) -> List[Union[Tag, NavigableString]]:
     """
     Get page content to a table or a tag with its class in `SEARCH_END_TAG_ATTRS`.
 

--- a/monty/statsd.py
+++ b/monty/statsd.py
@@ -1,5 +1,6 @@
 import asyncio
 import socket
+from typing import cast
 
 from statsd.client.base import StatsClientBase
 
@@ -9,8 +10,7 @@ class AsyncStatsClient(StatsClientBase):
 
     def __init__(self, *, host: str, port: int, prefix: str = None):
         """Create a new client."""
-        _, _, _, _, addr = socket.getaddrinfo(host, port, socket.AF_INET, socket.SOCK_DGRAM)[0]
-        self._addr = addr
+        self._addr = (host, port)
         self._prefix = prefix
         self._transport = None
         self._loop = asyncio.get_running_loop()
@@ -18,9 +18,10 @@ class AsyncStatsClient(StatsClientBase):
 
     async def create_socket(self) -> None:
         """Use the loop.create_datagram_endpoint method to create a socket."""
-        self._transport, _ = await self._loop.create_datagram_endpoint(
+        transport, _ = await self._loop.create_datagram_endpoint(
             asyncio.DatagramProtocol, family=socket.AF_INET, remote_addr=self._addr
         )
+        self._transport = cast(asyncio.DatagramTransport, transport)
 
     def _send(self, data: str) -> None:
         """Start an async task to send data to statsd."""
@@ -28,4 +29,5 @@ class AsyncStatsClient(StatsClientBase):
 
     async def _async_send(self, data: str) -> None:
         """Send data to the statsd server using the async transport."""
+        assert self._transport
         self._transport.sendto(data.encode("utf-8"), self._addr)

--- a/monty/statsd.py
+++ b/monty/statsd.py
@@ -10,7 +10,7 @@ class AsyncStatsClient(StatsClientBase):
 
     def __init__(self, *, host: str, port: int, prefix: str = None):
         """Create a new client."""
-        self._addr = (host, port)
+        self._addr = (socket.gethostbyname(host), port)
         self._prefix = prefix
         self._transport = None
         self._loop = asyncio.get_running_loop()

--- a/monty/utils/__init__.py
+++ b/monty/utils/__init__.py
@@ -63,7 +63,7 @@ async def disambiguate(
 
         # wait_for timeout will go to except instead of the wait_for thing as I expected
         futures = [asyncio.ensure_future(coro1), asyncio.ensure_future(coro2)]
-        done, pending = await asyncio.wait(futures, return_when=asyncio.FIRST_COMPLETED, loop=ctx.bot.loop)
+        done, pending = await asyncio.wait(futures, return_when=asyncio.FIRST_COMPLETED)
 
         # :yert:
         result = list(done)[0].result()

--- a/monty/utils/converters.py
+++ b/monty/utils/converters.py
@@ -302,12 +302,12 @@ class SourceConverter(commands.Converter):
 
 
 if t.TYPE_CHECKING:
-    Extension = str  # noqa: F811
-    PackageName = str  # noqa: F811
-    ValidURL = str  # noqa: F811
-    Inventory = t.Tuple[str, inventory_parser.InventoryDict]  # noqa: F811
-    Snowflake = int  # noqa: F811
-    UnambiguousUser = disnake.User  # noqa: F811
-    UnambiguousMember = disnake.Member  # noqa: F811
-    WrappedMessageConverter = disnake.Message  # noqa: F811
-    SourceConverter = SourceType  # noqa: F811
+    Extension = str  # type: ignore  # noqa: F811
+    PackageName = str  # type: ignore  # noqa: F811
+    ValidURL = str  # type: ignore  # noqa: F811
+    Inventory = t.Tuple[str, inventory_parser.InventoryDict]  # type: ignore  # noqa: F811
+    Snowflake = int  # type: ignore  # noqa: F811
+    UnambiguousUser = disnake.User  # type: ignore  # noqa: F811
+    UnambiguousMember = disnake.Member  # type: ignore  # noqa: F811
+    WrappedMessageConverter = disnake.Message  # type: ignore  # noqa: F811
+    SourceConverter = SourceType  # type: ignore  # noqa: F811

--- a/monty/utils/extensions.py
+++ b/monty/utils/extensions.py
@@ -1,7 +1,7 @@
 import importlib
 import inspect
 import pkgutil
-from typing import TYPE_CHECKING, Generator, NewType, NoReturn, Tuple
+from typing import TYPE_CHECKING, Generator, NoReturn, Tuple
 
 from disnake.ext import commands
 
@@ -12,7 +12,6 @@ from monty.log import get_logger
 if TYPE_CHECKING:
     from monty.metadata import ExtMetadata
 
-ModuleName = NewType("ModuleName", str)
 log = get_logger(__name__)
 
 
@@ -21,7 +20,7 @@ def unqualify(name: str) -> str:
     return name.rsplit(".", maxsplit=1)[-1]
 
 
-def walk_extensions() -> Generator[Tuple[ModuleName, "ExtMetadata"], None, None]:
+def walk_extensions() -> Generator[Tuple[str, "ExtMetadata"], None, None]:
     """Yield extension names from monty.exts subpackage."""
     from monty.metadata import ExtMetadata
 
@@ -38,7 +37,7 @@ def walk_extensions() -> Generator[Tuple[ModuleName, "ExtMetadata"], None, None]
             # If it lacks a setup function, it's not an extension.
             continue
 
-        ext_metadata: ExtMetadata = getattr(imported, "EXT_METADATA", None)
+        ext_metadata = getattr(imported, "EXT_METADATA", None)
         if ext_metadata is not None:
             if not isinstance(ext_metadata, ExtMetadata):
                 if ext_metadata == ExtMetadata:
@@ -69,7 +68,7 @@ async def invoke_help_command(ctx: commands.Context) -> None:
     """Invoke the help command or default help command if help extensions is not loaded."""
     if "monty.exts.backend.help" in ctx.bot.extensions:
         help_command = ctx.bot.get_command("help")
-        await ctx.invoke(help_command, ctx.command.qualified_name)
+        await ctx.invoke(help_command, ctx.command.qualified_name)  # type: ignore
         return
     await ctx.send_help(ctx.command)
 

--- a/monty/utils/html_parsing.py
+++ b/monty/utils/html_parsing.py
@@ -229,22 +229,24 @@ def _get_truncated_description(
     return truncated_result.strip(_TRUNCATE_STRIP_CHARACTERS) + "..."
 
 
-def _create_markdown(signatures: Optional[List[str]], description: Iterable[Tag], url: str) -> str:
+def _create_markdown(
+    signatures: Optional[List[str]], description: Iterable[Union[Tag, NavigableString]], url: str
+) -> str:
     """
     Create a Markdown string with the signatures at the top, and the converted html description below them.
 
     The signatures are wrapped in python codeblocks, separated from the description by a newline.
     The result Markdown string is max 750 rendered characters for the description with signatures at the start.
     """
-    description = _get_truncated_description(
+    description_str = _get_truncated_description(
         description, markdown_converter=DocMarkdownConverter(bullets="•", page_url=url), max_length=750, max_lines=13
     )
-    description = _WHITESPACE_AFTER_NEWLINES_RE.sub("", description)
+    description_str = _WHITESPACE_AFTER_NEWLINES_RE.sub("", description_str)
     if signatures is not None:
         signature = "".join(f"```py\n{signature}```" for signature in _truncate_signatures(signatures))
-        return f"{signature}\n{description}"
+        return f"{signature}\n{description_str}"
     else:
-        return description
+        return description_str
 
 
 def get_symbol_markdown(soup: BeautifulSoup, symbol_data: DocItem) -> Optional[str]:

--- a/monty/utils/pagination.py
+++ b/monty/utils/pagination.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Iterable, List, Optional, Tuple, Union
+from typing import Iterable, List, Optional, Tuple, Union, cast
 
 import disnake
 from disnake.ext import commands
@@ -170,7 +170,7 @@ class LinePaginator(commands.Paginator):
                 raise EmptyPaginatorEmbedError("No lines to paginate")
 
             log.debug("No lines to add to paginator, adding '(nothing to display)' message")
-            lines.append("(nothing to display)")
+            lines = ("(nothing to display)",)
 
         for line in lines:
             try:
@@ -234,7 +234,8 @@ class LinePaginator(commands.Paginator):
                 log.debug("Timed out waiting for a reaction")
                 break  # We're done, no reactions for the last 5 minutes
 
-            event_name = inter.component.custom_id[len(CUSTOM_ID_PREFIX) :]
+            custom_id = cast(str, inter.component.custom_id)
+            event_name = custom_id[len(CUSTOM_ID_PREFIX) :]
 
             if PAGINATION_EMOJI.get(event_name) == DELETE_EMOJI:  # Note: DELETE_EMOJI is a string and not unicode
                 log.debug("Got delete inter")
@@ -420,6 +421,8 @@ class ImagePaginator(commands.Paginator):
 
             # Deletes the users reaction
             await message.remove_reaction(reaction.emoji, user)
+
+            reaction_type = "unknown"
 
             # Delete reaction press - [:trashcan:]
             if str(reaction.emoji) == DELETE_EMOJI:  # Note: DELETE_EMOJI is a string and not unicode

--- a/monty/utils/scheduling.py
+++ b/monty/utils/scheduling.py
@@ -8,6 +8,9 @@ from functools import partial
 from monty.log import get_logger
 
 
+T = t.TypeVar("T")
+
+
 class Scheduler:
     """
     Schedule the execution of coroutines and keep track of them.
@@ -162,12 +165,12 @@ class Scheduler:
 
 
 def create_task(
-    coro: t.Awaitable,
+    coro: t.Coroutine[t.Any, t.Any, T],
     *,
-    suppressed_exceptions: tuple[t.Type[Exception]] = (),
+    suppressed_exceptions: tuple[t.Type[Exception], ...] = (),
     event_loop: t.Optional[asyncio.AbstractEventLoop] = None,
     **kwargs,
-) -> asyncio.Task:
+) -> asyncio.Task[T]:
     """
     Wrapper for creating asyncio `Task`s which logs exceptions raised in the task.
 
@@ -181,7 +184,7 @@ def create_task(
     return task
 
 
-def _log_task_exception(task: asyncio.Task, *, suppressed_exceptions: t.Tuple[t.Type[Exception]]) -> None:
+def _log_task_exception(task: asyncio.Task, *, suppressed_exceptions: t.Tuple[t.Type[Exception], ...]) -> None:
     """Retrieve and log the exception raised in `task` if one exists."""
     with contextlib.suppress(asyncio.CancelledError):
         exception = task.exception()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,3 +94,5 @@ include = [
     "monty",
     "*.py",
 ]
+
+strictParameterNoneValue = false


### PR DESCRIPTION
Fixes a couple typing issues, mainly in `monty.utils`, lowering the error count by about 50.
Entirely untested as I currently don't have a proper environment with pg and redis set up, but they're largely non-runtime changes anyway.