### PR TITLE
fix(char-info): add f-string on error message

### DIFF
--- a/monty/exts/info/utils.py
+++ b/monty/exts/info/utils.py
@@ -41,7 +41,8 @@ class Utils(commands.Cog, slash_command_attrs={"dm_permission": False}):
             return
 
         if len(characters) > 50:
-            await ctx.send("Too many characters ({len(characters)}/50)")
+            await ctx.send(f"Too many characters ({len(characters)}*50)")
+            return
 
         def get_info(char: str) -> Tuple[str, str]:
             digit = f"{ord(char):x}"


### PR DESCRIPTION
This pull request adds an f-string to one of the error messages, as it would return that exact message, with no formatting. It also changes the division to multiplication on the same error message.

~~And yes, I accidently committed as `root`~~