### PR TITLE
refactor(exts): add spaced out names to cogs

### DIFF
--- a/monty/exts/api/realpython.py
+++ b/monty/exts/api/realpython.py
@@ -24,7 +24,7 @@ ERROR_EMBED = disnake.Embed(
 )
 
 
-class RealPython(commands.Cog, slash_command_attrs={"dm_permission": False}):
+class RealPython(commands.Cog, name="Real Python", slash_command_attrs={"dm_permission": False}):
     """User initiated command to search for a Real Python article."""
 
     def __init__(self, bot: bot.Monty) -> None:

--- a/monty/exts/api/stackoverflow.py
+++ b/monty/exts/api/stackoverflow.py
@@ -24,7 +24,7 @@ ERR_EMBED = disnake.Embed(
 )
 
 
-class Stackoverflow(commands.Cog, slash_command_attrs={"dm_permission": False}):
+class Stackoverflow(commands.Cog, name="Stack Overflow", slash_command_attrs={"dm_permission": False}):
     """Contains command to interact with stackoverflow from disnake."""
 
     def __init__(self, bot: bot.Monty) -> None:

--- a/monty/exts/api/wikipedia.py
+++ b/monty/exts/api/wikipedia.py
@@ -31,7 +31,7 @@ WIKI_SNIPPET_REGEX = r"(<!--.*?-->|<[^>]*>)"
 WIKI_SEARCH_RESULT = "**[{name}]({url})**\n" "{description}\n"
 
 
-class WikipediaSearch(commands.Cog, slash_command_attrs={"dm_permission": False}):
+class WikipediaSearch(commands.Cog, name="Wikipedia Search", slash_command_attrs={"dm_permission": False}):
     """Get info from wikipedia."""
 
     def __init__(self, bot: Monty) -> None:

--- a/monty/exts/backend/bot_features.py
+++ b/monty/exts/backend/bot_features.py
@@ -20,7 +20,7 @@ else:
 logger = get_logger(__name__)
 
 
-class FeatureManagement(commands.Cog):
+class FeatureManagement(commands.Cog, name="Feature Management"):
     """Management commands for bot features."""
 
     def __init__(self, bot: Monty) -> None:

--- a/monty/exts/backend/rollouts.py
+++ b/monty/exts/backend/rollouts.py
@@ -35,7 +35,7 @@ else:
 logger = get_logger(__name__)
 
 
-class RolloutCog(commands.Cog):
+class RolloutCog(commands.Cog, name="Rollouts"):
     """Management commands for bot rollouts."""
 
     def __init__(self, bot: Monty) -> None:

--- a/monty/exts/filters/token_remover.py
+++ b/monty/exts/filters/token_remover.py
@@ -74,7 +74,7 @@ class Token:
         return f"{self.user_id}.{self.timestamp}.{self.hmac}"
 
 
-class TokenRemover(commands.Cog, slash_command_attrs={"dm_permission": False}):
+class TokenRemover(commands.Cog, name="Token Remover", slash_command_attrs={"dm_permission": False}):
     """Scans messages for potential discord client tokens and removes them."""
 
     def __init__(self, bot: Monty) -> None:

--- a/monty/exts/filters/webhook_remover.py
+++ b/monty/exts/filters/webhook_remover.py
@@ -23,7 +23,7 @@ WEBHOOK_REMOVER_FEATURE_NAME = "DISCORD_WEBHOOK_FILTER"
 log = get_logger(__name__)
 
 
-class WebhookRemover(commands.Cog, slash_command_attrs={"dm_permission": False}):
+class WebhookRemover(commands.Cog, name="Webhook Remover", slash_command_attrs={"dm_permission": False}):
     """Scan messages to detect Discord webhooks links."""
 
     def __init__(self, bot: Monty) -> None:

--- a/monty/exts/info/codeblock_commands.py
+++ b/monty/exts/info/codeblock_commands.py
@@ -31,8 +31,9 @@ PASTE_REGEX = re.compile(
 MAX_LEN = 30_000
 
 
-class CodeButtons(
+class CodeBlockActions(
     commands.Cog,
+    name="Code Block Actions",
     slash_command_attrs={"dm_permission": False},
     message_command_attrs={"dm_permission": False},
 ):
@@ -389,8 +390,8 @@ class CodeButtons(
 
 
 def setup(bot: Monty) -> None:
-    """Add the CodeButtons cog to the bot."""
+    """Add the CodeBlockActions cog to the bot."""
     if not URLs.black_formatter:
         logger.warning("Not loading codeblock buttons as black_formatter is not set.")
         return
-    bot.add_cog(CodeButtons(bot))
+    bot.add_cog(CodeBlockActions(bot))

--- a/monty/exts/info/codesnippets.py
+++ b/monty/exts/info/codesnippets.py
@@ -52,7 +52,7 @@ BITBUCKET_RE = re.compile(
 BLACKLIST = []
 
 
-class CodeSnippets(commands.Cog, slash_command_attrs={"dm_permission": False}):
+class CodeSnippets(commands.Cog, name="Code Snippets", slash_command_attrs={"dm_permission": False}):
     """
     commands.Cog that parses and sends code snippets to disnake.
 

--- a/monty/exts/info/docs/_cog.py
+++ b/monty/exts/info/docs/_cog.py
@@ -174,7 +174,7 @@ class DocView(DeleteView):
                 c.disabled = True
 
 
-class DocCog(commands.Cog, slash_command_attrs={"dm_permission": False}):
+class DocCog(commands.Cog, name="Documentation", slash_command_attrs={"dm_permission": False}):
     """A set of commands for querying & displaying documentation."""
 
     def __init__(self, bot: Monty) -> None:

--- a/monty/exts/info/github_info.py
+++ b/monty/exts/info/github_info.py
@@ -162,7 +162,7 @@ class GithubCache:
             yield
 
 
-class GithubInfo(commands.Cog, slash_command_attrs={"dm_permission": False}):
+class GithubInfo(commands.Cog, name="GitHub Information", slash_command_attrs={"dm_permission": False}):
     """Fetches info from GitHub."""
 
     def __init__(self, bot: Monty) -> None:

--- a/monty/exts/info/global_source.py
+++ b/monty/exts/info/global_source.py
@@ -21,7 +21,7 @@ logger = get_logger(__name__)
 CODE_FILE = os.path.dirname(__file__) + "/_global_source_snekcode.py"
 
 
-class GlobalSource(commands.Cog):
+class GlobalSource(commands.Cog, name="Global Source"):
     """Global source for python objects."""
 
     def __init__(self, bot: Monty) -> None:

--- a/monty/exts/info/pep.py
+++ b/monty/exts/info/pep.py
@@ -59,7 +59,7 @@ class PEPHeaders:
         return headers
 
 
-class PythonEnhancementProposals(commands.Cog, slash_command_attrs={"dm_permission": False}):
+class PythonEnhancementProposals(commands.Cog, name="PEPs", slash_command_attrs={"dm_permission": False}):
     """Cog for displaying information about PEPs."""
 
     def __init__(self, bot: Monty) -> None:

--- a/monty/exts/info/source.py
+++ b/monty/exts/info/source.py
@@ -97,7 +97,7 @@ class FrozenChainMap(Mapping[K, V]):
         return self.__class__(m, *self.maps)
 
 
-class MetaSource(commands.Cog, slash_command_attrs={"dm_permission": False}):
+class MetaSource(commands.Cog, name="Meta Source", slash_command_attrs={"dm_permission": False}):
     """Display information about my own source code."""
 
     def __init__(self, bot: Monty) -> None:

--- a/monty/exts/utils/status_codes.py
+++ b/monty/exts/utils/status_codes.py
@@ -11,7 +11,7 @@ HTTP_DOG_URL = "https://httpstatusdogs.com/img/{code}.jpg"
 HTTP_CAT_URL = "https://http.cat/{code}.jpg"
 
 
-class HTTPStatusCodes(commands.Cog, slash_command_attrs={"dm_permission": False}):
+class HTTPStatusCodes(commands.Cog, name="HTTP Status Codes", slash_command_attrs={"dm_permission": False}):
     """
     Fetch an image depicting HTTP status codes as a dog or a cat.
 

--- a/monty/exts/utils/timed.py
+++ b/monty/exts/utils/timed.py
@@ -7,7 +7,7 @@ from disnake.ext import commands
 from monty.bot import Monty
 
 
-class TimedCommands(commands.Cog, slash_command_attrs={"dm_permission": False}):
+class TimedCommands(commands.Cog, name="Timed Commands", slash_command_attrs={"dm_permission": False}):
     """Time the command execution of a command."""
 
     @staticmethod


### PR DESCRIPTION
This uses the `name` kwarg for `Cog` subclasses. Reason being that they look quite weird on the help command.

NOTE: Has not been tested ~~because I have no idea how this bot works :^)~~
