### PR TITLE
feat: expand GitHub issue links

### DIFF
--- a/monty/exts/info/github_info.py
+++ b/monty/exts/info/github_info.py
@@ -950,15 +950,11 @@ class GithubInfo(commands.Cog, name="GitHub Information", slash_command_attrs={"
                         pass
                 await message.edit(suppress_embeds=True)
 
-            scheduling.create_task(remove_embeds())
-            expand_one_issue = True
-        elif await self.bot.guild_has_feature(
-            message.guild,
-            ISSUE_EXPAND_FEATURE_NAME,
-        ):
+            if perms.manage_messages:
+                scheduling.create_task(remove_embeds())
             expand_one_issue = True
         else:
-            expand_one_issue = False
+            expand_one_issue = await self.bot.guild_has_feature(message.guild, ISSUE_EXPAND_FEATURE_NAME)
 
         embed = self.format_embed(links, expand_one_issue=expand_one_issue)
         log.debug(f"Sending GitHub issues to {message.channel} in guild {message.guild}.")

--- a/monty/exts/info/github_info.py
+++ b/monty/exts/info/github_info.py
@@ -957,7 +957,7 @@ class GithubInfo(commands.Cog, name="GitHub Information", slash_command_attrs={"
         log.debug(f"Sending GitHub issues to {message.channel} in guild {message.guild}.")
         components: List[disnake.ui.Button] = [DeleteButton(message.author)]
         if expand_one_issue:
-            button = self.get_expand_button(links, user_id=message.author.id, is_expanded=expand_one_issue)
+            button = self.get_expand_button(links, user_id=message.author.id)
             if button:
                 components.append(button)
 

--- a/monty/exts/info/github_info.py
+++ b/monty/exts/info/github_info.py
@@ -953,11 +953,11 @@ class GithubInfo(commands.Cog, name="GitHub Information", slash_command_attrs={"
         else:
             expand_one_issue = False
 
-        embed = self.format_embed(links)
+        embed = self.format_embed(links, expand_one_issue=expand_one_issue)
         log.debug(f"Sending GitHub issues to {message.channel} in guild {message.guild}.")
         components: List[disnake.ui.Button] = [DeleteButton(message.author)]
         if expand_one_issue:
-            button = self.get_expand_button(links, user_id=message.author.id)
+            button = self.get_expand_button(links, user_id=message.author.id, is_expanded=expand_one_issue)
             if button:
                 components.append(button)
 

--- a/monty/exts/info/github_info.py
+++ b/monty/exts/info/github_info.py
@@ -936,7 +936,11 @@ class GithubInfo(commands.Cog, name="GitHub Information", slash_command_attrs={"
         if len(links) == 1 and issues[0].should_be_expanded:
 
             async def remove_embeds() -> None:
-                await asyncio.sleep(1.5)
+                if not message.embeds:
+                    try:
+                        await self.bot.wait_for("message_edit", check=lambda b, m: m.id == message.id, timeout=3)
+                    except asyncio.TimeoutError:
+                        pass
                 await message.edit(suppress_embeds=True)
 
             scheduling.create_task(remove_embeds())


### PR DESCRIPTION
by default we now show this instead of the discord embed for issues.

todo: 
- configuration option
  - edit: made this a feature lock for the time being
- more testing of behavior when a message is edited
- testing of when multiple links are provided