### PR TITLE
feat: better markdown previews for GitHub issues

### DIFF
--- a/monty/constants.py
+++ b/monty/constants.py
@@ -140,6 +140,7 @@ class Emojis:
 
     confirmation = "\u2705"
     decline = "\u274c"
+    no_choice_light = "\u25fb\ufe0f"
 
     x = "\U0001f1fd"
     o = "\U0001f1f4"

--- a/monty/exts/info/github_info.py
+++ b/monty/exts/info/github_info.py
@@ -254,7 +254,15 @@ class GithubInfo(commands.Cog, name="GitHub Information", slash_command_attrs={"
 
     def render_github_markdown(self, body: str, *, context: RenderContext = None, limit: int = 700) -> str:
         """Render GitHub Flavored Markdown to Discord flavoured markdown."""
-        markdown = mistune.create_markdown(escape=False, renderer=DiscordRenderer(), plugins=["task_lists"])
+        markdown = mistune.create_markdown(
+            escape=False,
+            renderer=DiscordRenderer(),
+            plugins=[
+                "strikethrough",
+                "task_lists",
+                "url",
+            ],
+        )
         body = markdown(body) or ""
 
         if len(body) > limit:

--- a/monty/exts/info/github_info.py
+++ b/monty/exts/info/github_info.py
@@ -252,7 +252,7 @@ class GithubInfo(commands.Cog, name="GitHub Information", slash_command_attrs={"
                     await self.request_cache.set(cache_key, (None, body), timeout=timedelta(minutes=30).total_seconds())
                 return body
 
-    def render_github_markdown(self, body: str, *, context: RenderContext = None, limit: int = 700) -> str:
+    def render_github_markdown(self, body: str, *, context: RenderContext = None, limit: int = 2700) -> str:
         """Render GitHub Flavored Markdown to Discord flavoured markdown."""
         markdown = mistune.create_markdown(
             escape=False,

--- a/monty/exts/info/github_info.py
+++ b/monty/exts/info/github_info.py
@@ -254,7 +254,7 @@ class GithubInfo(commands.Cog, name="GitHub Information", slash_command_attrs={"
 
     def render_github_markdown(self, body: str, *, context: RenderContext = None, limit: int = 700) -> str:
         """Render GitHub Flavored Markdown to Discord flavoured markdown."""
-        markdown = mistune.create_markdown(escape=False, renderer=DiscordRenderer())
+        markdown = mistune.create_markdown(escape=False, renderer=DiscordRenderer(), plugins=["task_lists"])
         body = markdown(body) or ""
 
         if len(body) > limit:

--- a/monty/exts/info/github_info.py
+++ b/monty/exts/info/github_info.py
@@ -254,9 +254,10 @@ class GithubInfo(commands.Cog, name="GitHub Information", slash_command_attrs={"
 
     def render_github_markdown(self, body: str, *, context: RenderContext = None, limit: int = 2700) -> str:
         """Render GitHub Flavored Markdown to Discord flavoured markdown."""
+        url_prefix = context and context.html_url
         markdown = mistune.create_markdown(
             escape=False,
-            renderer=DiscordRenderer(),
+            renderer=DiscordRenderer(repo=url_prefix),
             plugins=[
                 "strikethrough",
                 "task_lists",
@@ -662,7 +663,9 @@ class GithubInfo(commands.Cog, name="GitHub Information", slash_command_attrs={"
         body: Optional[str] = json_data["body"]
         if body and not body.isspace():
             # escape wack stuff from the markdown
-            embed.description = self.render_github_markdown(body, context=None)
+            embed.description = self.render_github_markdown(
+                body, context=RenderContext(user=issue.organisation, repo=issue.repository)
+            )
         if not body or body.isspace():
             embed.description = "*No description provided.*"
         return embed

--- a/monty/utils/markdown.py
+++ b/monty/utils/markdown.py
@@ -6,6 +6,8 @@ import mistune.renderers
 from bs4.element import PageElement, Tag
 from markdownify import MarkdownConverter
 
+from monty import constants
+
 
 # taken from version 0.6.1 of markdownify
 WHITESPACE_RE = re.compile(r"[\r\n\s\t ]+")
@@ -187,12 +189,17 @@ class DiscordRenderer(mistune.renderers.BaseRenderer):
         return text + "\n"
 
     def list(self, text: str, ordered: bool, level: int, start: Any = None) -> str:
-        """Do nothing when encountering a list."""
-        return ""
+        """Return the unedited list."""
+        return text
 
     def list_item(self, text: Any, level: int) -> str:
-        """Do nothing when encountering a list."""
-        return ""
+        """Show the list, indented to its proper level."""
+        return "\u200b   " * (level - 1) * 8 + f"- {text}\n"
+
+    def task_list_item(self, text: Any, level: int, checked: bool = False, **attrs) -> str:
+        """Convert task list options to emoji."""
+        emoji = constants.Emojis.confirmation if checked else constants.Emojis.no_choice_light
+        return self.list_item(emoji + " " + text, level=level)
 
     def finalize(self, data: Any) -> str:
         """Finalize the data."""

--- a/monty/utils/markdown.py
+++ b/monty/utils/markdown.py
@@ -178,7 +178,7 @@ class DiscordRenderer(mistune.renderers.BaseRenderer):
     def block_quote(self, text: str) -> str:
         """Quote the provided text."""
         if text:
-            return "> " + "> ".join(text.splitlines(keepends=True)) + "\n"
+            return "> " + "> ".join(text.rstrip().splitlines(keepends=True)) + "\n"
         return ""
 
     def block_html(self, html: str) -> str:

--- a/monty/utils/markdown.py
+++ b/monty/utils/markdown.py
@@ -140,7 +140,15 @@ class DiscordRenderer(mistune.renderers.BaseRenderer):
 
     def linebreak(self) -> str:
         """Return two new lines."""
+        return "\n"
+
+    def blank_line(self) -> str:
+        """Return a blank line."""
         return "\n\n"
+
+    def softbreak(self) -> str:
+        """Return a softbreak."""
+        return "\n"
 
     def inline_html(self, html: str) -> str:
         """No op."""
@@ -186,15 +194,18 @@ class DiscordRenderer(mistune.renderers.BaseRenderer):
 
     def paragraph(self, text: str) -> str:
         """Return a paragraph with a newline postceeding."""
-        return text + "\n"
+        return f"{text}\n"
 
     def list(self, text: str, ordered: bool, level: int, start: Any = None) -> str:
         """Return the unedited list."""
-        return text
+        # todo: figure out how this should actually work
+        if level != 1:
+            return text
+        return text.lstrip("\n") + "\n"
 
     def list_item(self, text: Any, level: int) -> str:
         """Show the list, indented to its proper level."""
-        return "\u200b   " * (level - 1) * 8 + f"- {text}\n"
+        return "\n" + "\u200b " * (level - 1) * 8 + f"- {text}"
 
     def task_list_item(self, text: Any, level: int, checked: bool = False, **attrs) -> str:
         """Convert task list options to emoji."""

--- a/monty/utils/markdown.py
+++ b/monty/utils/markdown.py
@@ -166,7 +166,7 @@ class DiscordRenderer(mistune.renderers.BaseRenderer):
     def block_quote(self, text: str) -> str:
         """Quote the provided text."""
         if text:
-            return "> " + "> ".join(text) + "\n"
+            return "> " + "> ".join(text.splitlines(keepends=True)) + "\n"
         return ""
 
     def block_html(self, html: str) -> str:

--- a/monty/utils/markdown.py
+++ b/monty/utils/markdown.py
@@ -98,8 +98,18 @@ class DocMarkdownConverter(MarkdownConverter):
 class DiscordRenderer(mistune.renderers.BaseRenderer):
     """Custom renderer for markdown to discord compatiable markdown."""
 
+    def __init__(self, repo: str = None):
+        self._repo = (repo or "").rstrip("/")
+
     def text(self, text: str) -> str:
-        """No op."""
+        """Replace GitHub links with their expanded versions."""
+        if self._repo:
+            # todo: expand this to all different varieties of automatic links
+            # if a repository is provided we replace all snippets with the correct thing
+            def replacement(match: re.Match[str]) -> str:
+                return self.link(self._repo + "/issues/" + match[1], text=match[0])
+
+            return re.sub(r"(?:GH-|#)(\d+)", replacement, text)
         return text
 
     def link(self, link: str, text: Optional[str] = None, title: Optional[str] = None) -> str:

--- a/monty/utils/markdown.py
+++ b/monty/utils/markdown.py
@@ -9,6 +9,11 @@ from markdownify import MarkdownConverter
 from monty import constants
 
 
+__all__ = (
+    "remove_codeblocks",
+    "DocMarkdownConverter",
+    "DiscordRenderer",
+)
 # taken from version 0.6.1 of markdownify
 WHITESPACE_RE = re.compile(r"[\r\n\s\t ]+")
 
@@ -17,6 +22,8 @@ CODE_BLOCK_RE = re.compile(
     r"(?P<delim>`{1,2})([^\n]+)(?P=delim)|```(.+?)```",
     re.DOTALL | re.MULTILINE,
 )
+
+GH_ISSUE_RE = re.compile(r"(?:GH-|#)(\d+)")
 
 
 def remove_codeblocks(content: str) -> str:
@@ -109,7 +116,7 @@ class DiscordRenderer(mistune.renderers.BaseRenderer):
             def replacement(match: re.Match[str]) -> str:
                 return self.link(self._repo + "/issues/" + match[1], text=match[0])
 
-            return re.sub(r"(?:GH-|#)(\d+)", replacement, text)
+            return GH_ISSUE_RE.sub(replacement, text)
         return text
 
     def link(self, link: str, text: Optional[str] = None, title: Optional[str] = None) -> str:

--- a/monty/utils/markdown.py
+++ b/monty/utils/markdown.py
@@ -115,9 +115,9 @@ class DiscordRenderer(mistune.renderers.BaseRenderer):
         else:
             return link
 
-    def image(self, src: str, alt: str = "", title: str = None) -> str:
+    def image(self, src: str, alt: str = None, title: str = None) -> str:
         """Return a link to the provided image."""
-        return self.link(src, text="image", title=title)
+        return self.link(src, text="!image", title=alt)
 
     def emphasis(self, text: str) -> str:
         """Return italiced text."""
@@ -140,7 +140,7 @@ class DiscordRenderer(mistune.renderers.BaseRenderer):
 
     def linebreak(self) -> str:
         """Return two new lines."""
-        return "\n"
+        return "\n\n"
 
     def blank_line(self) -> str:
         """Return a blank line."""

--- a/monty/utils/markdown.py
+++ b/monty/utils/markdown.py
@@ -173,7 +173,7 @@ class DiscordRenderer(mistune.renderers.BaseRenderer):
             lang = info.split(None, 1)[0]
             md += lang
         md += "\n"
-        return md + code.replace("`" * 3, "`\u200b" * 3) + "\n```"
+        return md + code.replace("`" * 3, "`\u200b" * 3) + "\n```\n"
 
     def block_quote(self, text: str) -> str:
         """Quote the provided text."""

--- a/monty/utils/markdown.py
+++ b/monty/utils/markdown.py
@@ -130,9 +130,9 @@ class DiscordRenderer(mistune.renderers.BaseRenderer):
     def heading(self, text: str, level: int) -> str:
         """Format the heading to be bold if its large enough. Otherwise underline it."""
         if level in (1, 2, 3):
-            return f"**{text}**\n"
+            return "\n" f"**{text}**\n"
         else:
-            return f"__{text}__\n"
+            return "\n" f"__{text}__\n"
 
     def newline(self) -> str:
         """Return a new line."""

--- a/monty/utils/markdown.py
+++ b/monty/utils/markdown.py
@@ -152,14 +152,6 @@ class DiscordRenderer(mistune.renderers.BaseRenderer):
         """Return two new lines."""
         return "\n\n"
 
-    def blank_line(self) -> str:
-        """Return a blank line."""
-        return "\n\n"
-
-    def softbreak(self) -> str:
-        """Return a softbreak."""
-        return "\n"
-
     def inline_html(self, html: str) -> str:
         """No op."""
         return ""
@@ -204,14 +196,14 @@ class DiscordRenderer(mistune.renderers.BaseRenderer):
 
     def paragraph(self, text: str) -> str:
         """Return a paragraph with a newline postceeding."""
-        return f"{text}\n"
+        return f"{text}\n\n"
 
     def list(self, text: str, ordered: bool, level: int, start: Any = None) -> str:
         """Return the unedited list."""
         # todo: figure out how this should actually work
         if level != 1:
             return text
-        return text.lstrip("\n") + "\n"
+        return text.lstrip("\n") + "\n\n"
 
     def list_item(self, text: Any, level: int) -> str:
         """Show the list, indented to its proper level."""


### PR DESCRIPTION
Improves the previews for GitHub issues. This should be the last blocker before rolling out expanded descriptions across the entire bot.

https://github.com/DisnakeDev/disnake/pull/986
![short issue, with a checklist, dark mode](https://user-images.githubusercontent.com/71233171/226527412-95f359a3-fd71-4833-af67-f4e00289758a.png)
![short issue, with a checklist, dark mode](https://user-images.githubusercontent.com/71233171/226527433-24deda2f-15a2-409b-b101-6de682d10879.png)

https://github.com/starlite-api/starlite/pull/1317
![long issue, dark mode preview](https://user-images.githubusercontent.com/71233171/226527389-3d901e74-6c9b-4fbd-904e-ce7632bd46a4.png)
![long issue, light mode preview](https://user-images.githubusercontent.com/71233171/226527453-729d6f32-818a-4a16-a5dc-24b291e0cf0c.png)
