### PR TITLE
fix(gh-issues): only match exact issue urls

### DIFF
--- a/monty/exts/info/github_info.py
+++ b/monty/exts/info/github_info.py
@@ -773,6 +773,10 @@ class GithubInfo(commands.Cog, name="GitHub Information", slash_command_attrs={"
                 should_be_expanded = True
                 # handle custom checks here
                 url = yarl.URL(match[0])
+
+                # don't match if we didn't end with the hash
+                if not url.path.rstrip("/").endswith(match.group("number")):
+                    continue
                 if url.fragment or url.query:  # saving fragments for later
                     continue
             else:


### PR DESCRIPTION
Rather than matching `https://github.com/onerandomusername/monty-python/pull/231/commits/` we only want to match `https://github.com/onerandomusername/monty-python/pull/231/` or `https://github.com/onerandomusername/monty-python/pull/231` (outside of codeblocks)