### PR TITLE
fix: ignore parenthesis on GitHub issue expansion regex matching

### DIFF
--- a/monty/exts/info/github_info.py
+++ b/monty/exts/info/github_info.py
@@ -72,7 +72,7 @@ AUTOMATIC_REGEX = re.compile(
 
 GITHUB_ISSUE_LINK_REGEX = re.compile(
     r"https?:\/\/github.com\/(?P<org>[a-zA-Z0-9][a-zA-Z0-9\-]{1,39})\/(?P<repo>[\w\-\.]{1,100})\/"
-    r"(?P<type>issues|pull)\/(?P<number>[0-9]+)[^\s<>]*"
+    r"(?P<type>issues|pull)\/(?P<number>[0-9]+)[^\s<>)]?"
 )
 
 


### PR DESCRIPTION
When a GitHub link is parenthetically wrapped, it causes the regex match to fail.
Example:
```
Yeah that is fixed (See: https://github.com/issues/1)
```
Would fail because the ending issue ID is touching a paren..

This resolves that.