### PR TITLE
feat: add python discourse autolinking

### DIFF
--- a/monty/constants.py
+++ b/monty/constants.py
@@ -170,6 +170,7 @@ class Icons:
         "https://images-ext-2.discordapp.net/external/zl4oDwcmxUILY7sD9ZWE2fU5R7n6QcxEmPYSE5eddbg/"
         "%3Fv%3D1/https/cdn.discordapp.com/emojis/654080405988966419.png?width=20&height=20"
     )
+    python_discourse = "https://global.discourse-cdn.com/business6/uploads/python1/optimized/1X/4c06143de7870c35963b818b15b395092a434991_2_180x180.png"  # noqa: E501
 
 
 class URLs:

--- a/monty/exts/info/python_discourse.py
+++ b/monty/exts/info/python_discourse.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any, Optional, Union
+from urllib.parse import urljoin
+
+import disnake
+from cachingutils import LRUMemoryCache, async_cached
+from disnake.ext import commands
+
+from monty.bot import Monty
+from monty.constants import Icons
+from monty.log import get_logger
+from monty.utils import scheduling
+from monty.utils.messages import DeleteButton, suppress_embeds
+
+
+DOMAIN = "https://discuss.python.org"
+TOPIC_REGEX = re.compile(
+    r"https?:\/\/discuss\.python\.org\/t\/(?:[^\s\/]*\/)*?(?P<num>\d+)(?:\/(?P<reply>\d+))?[^\s<>)]*"
+)
+# https://docs.discourse.org/#tag/Posts
+TOPIC_API_URL = f"{DOMAIN}/t/{{id}}.json"
+# https://docs.discourse.org/#tag/Topics
+POST_API_URL = f"{DOMAIN}/posts/{{id}}.json"
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class DiscussionTopic:
+    id: int
+    url: str
+    reply_id: Optional[int] = None
+
+    def __init__(self, id: Union[int, str], url: str, reply: Optional[Union[str, int]] = None) -> None:
+        self.id = int(id)
+        self.url = url
+        self.reply_id = int(reply) if reply is not None else None
+
+    def __hash__(self) -> int:
+        return hash((self.id, self.reply_id))
+
+
+@dataclass
+class TopicInfo:
+    title: str
+    url: str
+
+
+class PythonDiscourse(commands.Cog):
+    """Autolink discuss.python.org discussions."""
+
+    def __init__(self, bot: Monty) -> None:
+        self.bot = bot
+
+    @async_cached(cache=LRUMemoryCache(50, timeout=int(timedelta(minutes=10).total_seconds())))
+    async def fetch_data(self, url: str) -> dict[str, Any]:
+        """Fetch the url. Results are cached."""
+        async with self.bot.http_session.get(url, raise_for_status=True) as r:
+            return await r.json()
+
+    async def fetch_post(self, topic: DiscussionTopic) -> tuple[dict[str, Any], TopicInfo]:
+        """Fetch a python discourse post knowing the topic and reply id."""
+        data = await self.fetch_data(TOPIC_API_URL.format(id=topic.id))  # type: ignore
+        posts = data["post_stream"]["posts"]
+        if topic.reply_id is not None:
+            post_id = next(filter(lambda p: p["post_number"] == topic.reply_id, posts))["id"]
+        else:
+            post_id = posts[0]["id"]
+
+        topic_info = TopicInfo(title=data["title"], url=f"{DOMAIN}/t/{data['slug']}/{data['id']}")
+
+        data = await self.fetch_data(POST_API_URL.format(id=post_id))  # type: ignore
+        return data, topic_info
+
+    def make_post_embed(self, data: dict[str, Any], topic_info: TopicInfo = None) -> disnake.Embed:
+        """Return an embed representing the provided post and topic information."""
+        # consider parsing this into markdown
+        e = disnake.Embed(description=data["raw"])
+
+        is_reply = data["post_number"] > 1
+        if topic_info and topic_info.title:
+            if is_reply:
+                e.title = "comment on " + topic_info.title
+            else:
+                e.title = topic_info.title
+
+        url = f"{DOMAIN}/t/{data['topic_slug']}/{data['topic_id']}"
+        if is_reply:
+            url += f"/{data['post_number']}"
+        e.url = url
+
+        author_url = urljoin(DOMAIN, data["avatar_template"].format(size="256"))
+        e.set_author(
+            name=data["name"],
+            icon_url=author_url,
+            url=f"{DOMAIN}/u/{data['username']}",
+        )
+
+        e.timestamp = datetime.strptime(data["created_at"], r"%Y-%m-%dT%H:%M:%S.%fZ")
+        e.set_footer(text="Posted at", icon_url=Icons.python_discourse)
+        return e
+
+    def extract_topic_urls(self, content: str) -> list[DiscussionTopic]:
+        """Extract python discourse urls from the provided content."""
+        posts = []
+        for match in TOPIC_REGEX.finditer(content):
+            posts.append(
+                DiscussionTopic(
+                    id=match.group("num"),
+                    url=match[0],
+                    reply=match.group("reply"),
+                )
+            )
+        return posts
+
+    @commands.Cog.listener("on_message")
+    async def on_message(self, message: disnake.Message) -> None:
+        """Automatically link python discourse urls."""
+        if message.author.bot:
+            return
+
+        if not message.guild:
+            return
+
+        if not message.content:
+            return
+
+        posts = self.extract_topic_urls(message.content)
+
+        if not posts:
+            return
+
+        posts = list(dict.fromkeys(posts, None))
+        my_perms = message.channel.permissions_for(message.guild.me)
+
+        if len(posts) > 4:
+            if my_perms.add_reactions:
+                await message.add_reaction(":x:")
+            await message.reply(
+                "I can only link 4 discussion urls at a time!.",
+                components=DeleteButton(message.author),
+                allowed_mentions=disnake.AllowedMentions(replied_user=False),
+                fail_if_not_exists=True,
+            )
+            return
+
+        embeds = []
+        components: list[disnake.ui.Button] = []
+        for post in posts:
+            data = await self.fetch_post(post)
+            embed = self.make_post_embed(*data)
+
+            embeds.append(embed)
+            components.append(disnake.ui.Button(url=embed.url, label="View comment"))
+
+        if len(posts) > 1:
+            for num, component in enumerate(components, 1):
+                if num == 1:
+                    suffix = "st"
+                elif num == 2:
+                    suffix = "nd"
+                elif num == 3:
+                    suffix = "rd"
+                else:
+                    suffix = "th"
+
+                component.label = f"View {num}{suffix} comment"
+
+        components.insert(0, DeleteButton(message.author))
+
+        if embeds:
+            if my_perms.manage_messages:
+                scheduling.create_task(suppress_embeds(self.bot, message))
+            await message.reply(embeds=embeds, components=components)
+
+
+def setup(bot: Monty) -> None:
+    """Add the Python Discourse cog to the bot."""
+    bot.add_cog(PythonDiscourse(bot))

--- a/monty/exts/info/python_discourse.py
+++ b/monty/exts/info/python_discourse.py
@@ -151,6 +151,7 @@ class PythonDiscourse(commands.Cog):
 
         embeds = []
         components: list[disnake.ui.Button] = []
+        chars = 0
         for post in posts:
             try:
                 data = await self.fetch_post(post)
@@ -158,6 +159,9 @@ class PythonDiscourse(commands.Cog):
                 continue
 
             embed = self.make_post_embed(*data)
+            chars += len(embed)
+            if chars > 6000:
+                break
 
             embeds.append(embed)
             components.append(disnake.ui.Button(url=embed.url, label="View comment"))

--- a/monty/exts/info/python_discourse.py
+++ b/monty/exts/info/python_discourse.py
@@ -18,6 +18,8 @@ from monty.utils import scheduling
 from monty.utils.messages import DeleteButton, suppress_embeds
 
 
+PYTHON_DISCOURSE_AUTOLINK_FEATURE = "PYTHON_DISCOURSE_AUTOLINK"
+
 DOMAIN = "https://discuss.python.org"
 TOPIC_REGEX = re.compile(
     r"https?:\/\/discuss\.python\.org\/t\/(?:[^\s\/]*\/)*?(?P<num>\d+)(?:\/(?P<reply>\d+))?[^\s<>)]*"
@@ -26,6 +28,7 @@ TOPIC_REGEX = re.compile(
 TOPIC_API_URL = f"{DOMAIN}/t/{{id}}.json"
 # https://docs.discourse.org/#tag/Topics
 POST_API_URL = f"{DOMAIN}/posts/{{id}}.json"
+
 
 logger = get_logger(__name__)
 
@@ -128,6 +131,9 @@ class PythonDiscourse(commands.Cog):
             return
 
         if not message.content:
+            return
+
+        if not await self.bot.guild_has_feature(message.guild, PYTHON_DISCOURSE_AUTOLINK_FEATURE):
             return
 
         posts = self.extract_topic_urls(message.content)

--- a/monty/exts/info/python_discourse.py
+++ b/monty/exts/info/python_discourse.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 from typing import Any, Optional, Union
 from urllib.parse import urljoin
 
+import aiohttp
 import disnake
 from cachingutils import LRUMemoryCache, async_cached
 from disnake.ext import commands
@@ -151,13 +152,17 @@ class PythonDiscourse(commands.Cog):
         embeds = []
         components: list[disnake.ui.Button] = []
         for post in posts:
-            data = await self.fetch_post(post)
+            try:
+                data = await self.fetch_post(post)
+            except aiohttp.ClientResponseError:
+                continue
+
             embed = self.make_post_embed(*data)
 
             embeds.append(embed)
             components.append(disnake.ui.Button(url=embed.url, label="View comment"))
 
-        if len(posts) > 1:
+        if len(components) > 1:
             for num, component in enumerate(components, 1):
                 if num == 1:
                     suffix = "st"


### PR DESCRIPTION
Adds an autolinker for https://discuss.python.org.

Pretty basic, only links topics and posts. The regex for url detection is not complete, as Discourse allows a plethora of ways to link to a post or topic.

todo:
- add a configuration option and generate migrations

later todo:
- add a dropdown configuration for all autolinkers

![image](https://user-images.githubusercontent.com/71233171/229049324-1e12d886-4363-4a29-82ce-ec9f803625d7.png)
