### PR TITLE
feat: show images uploaded in github issues

### DIFF
--- a/monty/exts/info/github_info.py
+++ b/monty/exts/info/github_info.py
@@ -292,12 +292,15 @@ class GithubInfo(commands.Cog, name="GitHub Information", slash_command_attrs={"
         encoded = encoded.rstrip("=")  # this isn't necessary, but github generates these IDs without padding
         return f"{prefix}_{encoded}"
 
-    def render_github_markdown(self, body: str, *, context: RenderContext = None, limit: int = 2700) -> str:
+    def render_github_markdown(
+        self, body: str, *, context: RenderContext = None, limit: int = 2700
+    ) -> tuple[str, list[tuple[str, ...]]]:
         """Render GitHub Flavored Markdown to Discord flavoured markdown."""
         url_prefix = context and context.html_url
+        renderer = DiscordRenderer(repo=url_prefix)
         markdown = mistune.create_markdown(
             escape=False,
-            renderer=DiscordRenderer(repo=url_prefix),
+            renderer=renderer,
             plugins=[
                 "strikethrough",
                 "task_lists",
@@ -307,9 +310,9 @@ class GithubInfo(commands.Cog, name="GitHub Information", slash_command_attrs={"
         body = markdown(body) or ""
 
         if len(body) > limit:
-            return body[: limit - 3] + "..."
+            body = body[: limit - 3] + "..."
 
-        return body
+        return body, renderer.images
 
     @redis_cache(
         "github-user-repos",
@@ -674,9 +677,12 @@ class GithubInfo(commands.Cog, name="GitHub Information", slash_command_attrs={"
         body: Optional[str] = json_data["body"]
         if body and not body.isspace():
             # escape wack stuff from the markdown
-            embed.description = self.render_github_markdown(
+            text, images = self.render_github_markdown(
                 body, context=RenderContext(user=issue.organisation, repo=issue.repository)
             )
+            embed.description = text
+            if len(images) == 1:
+                embed.set_image(images[0][0])
         if not body or body.isspace():
             embed.description = "*No description provided.*"
         return embed
@@ -1076,11 +1082,13 @@ class GithubInfo(commands.Cog, name="GitHub Information", slash_command_attrs={"
                 log.warning("[comment autolink] issue url %s does not match comment url %s", issue.user_url, html_url)
                 continue
 
-            body = self.render_github_markdown(comment["body"])
+            body, images = self.render_github_markdown(comment["body"])
             e = disnake.Embed(
                 url=html_url,
                 description=body,
             )
+            if len(images) == 1:
+                e.set_image(images[0][0])
 
             author = comment["user"]
             e.set_author(

--- a/monty/utils/markdown.py
+++ b/monty/utils/markdown.py
@@ -108,6 +108,7 @@ class DiscordRenderer(mistune.renderers.BaseRenderer):
 
     def __init__(self, repo: str = None):
         self._repo = (repo or "").rstrip("/")
+        self.images = []
 
     def text(self, text: str) -> str:
         """Replace GitHub links with their expanded versions."""
@@ -135,6 +136,7 @@ class DiscordRenderer(mistune.renderers.BaseRenderer):
 
     def image(self, src: str, alt: str = None, title: str = None) -> str:
         """Return a link to the provided image."""
+        self.images.append((src, alt, title))
         return "!" + self.link(src, text="image", title=alt)
 
     def emphasis(self, text: str) -> str:


### PR DESCRIPTION
needs a bit more work to restructure to instead show the images in a separate embed.

This also means that a single issue could take up to 5 embeds, so to prevent that problem we'll only show images if there's one issue