### PR TITLE
fix: improve markdown list handling

### DIFF
--- a/monty/utils/markdown.py
+++ b/monty/utils/markdown.py
@@ -220,12 +220,24 @@ class DiscordRenderer(mistune.renderers.BaseRenderer):
         indent = "\u2001" * (level - 1)
 
         result: list[str] = [f"{indent}- {lines[0]}"]
+
+        in_codeblock = "```" in lines[0]
         for line in lines[1:]:
             if not line.strip():
+                # whitespace-only lines can be rendered as empty
                 result.append("")
+                continue
+
+            if in_codeblock:
+                # don't indent lines inside codeblocks
+                result.append(line)
             else:
                 # the space here should be about the same width as `- `
                 result.append(f"{indent}\u2007{line}")
+
+            # check this at the end, since the first codeblock line should generally be indented
+            if "```" in line:
+                in_codeblock = not in_codeblock
 
         return "\n".join(result) + "\n"
 

--- a/monty/utils/markdown.py
+++ b/monty/utils/markdown.py
@@ -218,25 +218,9 @@ class DiscordRenderer(mistune.renderers.BaseRenderer):
         indent = "\u2001" * (level - 1)
 
         result: list[str] = [f"{indent}- {lines[0]}"]
-        in_codeblock = False
         for line in lines[1:]:
-            if "`" * 3 in line:  # very very very rudimentary codeblock detection
-                if in_codeblock:
-                    in_codeblock = False
-                    if line.endswith("\n"):
-                        line = line[:-1]
-                    result.append(line)
-                    continue
-                else:
-                    in_codeblock = True
-                line = line.lstrip()
             if not line.strip():
-                if in_codeblock:
-                    continue
                 result.append("")
-            elif in_codeblock:
-                result.append(line)
-                continue
             else:
                 # the space here should be about the same width as `- `
                 result.append(f"{indent}\u2007{line}")

--- a/monty/utils/markdown.py
+++ b/monty/utils/markdown.py
@@ -210,7 +210,9 @@ class DiscordRenderer(mistune.renderers.BaseRenderer):
         # todo: figure out how this should actually work
         if level == 1:
             return text.lstrip("\n") + "\n"
-        return text
+        else:
+            # inner lists need a newline prefix to show separately from parent item
+            return "\n" + text
 
     def list_item(self, text: str, level: int) -> str:
         """Show the list, indented to its proper level."""


### PR DESCRIPTION
Fixes https://canary.discord.com/channels/755868545279328417/1093642705759899678, rewriting/fixing the (still fairly simple) codeblock detection in the process.

The first commit is a revert, the diff becomes much more readable by skipping it.