### PR TITLE
fix: don't escape parentheses in github embed

### DIFF
--- a/monty/exts/info/github_info.py
+++ b/monty/exts/info/github_info.py
@@ -637,7 +637,7 @@ class GithubInfo(commands.Cog, name="GitHub Information", slash_command_attrs={"
         issue_count = 0
         for result in results:
             if isinstance(result, IssueState):
-                description_list.append(f"{result.emoji} [\\(#{result.number}\\) {result.title}]({result.url})")
+                description_list.append(f"{result.emoji} [(#{result.number}) {result.title}]({result.url})")
                 issue_count += 1
             elif show_errors_inline:
                 if isinstance(result, FetchError):


### PR DESCRIPTION
Seems like these are now being rendered on the latest canary build:
![image](https://user-images.githubusercontent.com/8530778/235768143-3ac8114f-7f4f-4a9e-a310-ced08c26262f.png)
... I don't think there's a reason to escape them there(?)