### PR TITLE
fix: increase suppress_embeds wait time to 6s

### DIFF
--- a/monty/utils/messages.py
+++ b/monty/utils/messages.py
@@ -58,7 +58,7 @@ async def suppress_embeds(
     bot: "Monty",
     message: disnake.Message,
     *,
-    wait: Optional[float] = 3,
+    wait: Optional[float] = 6,
     force_wait: bool = False,
 ) -> bool:
     """Suppress the embeds on the provided message, after waiting for an edit to add embeds if none exist."""


### PR DESCRIPTION
Increases the max wait time for `utils.messages.suppress_embeds` from 3s to 6s; there have been a few rare cases where Discord took longer than those 3 seconds to generate an embed, so it didn't get suppressed by the bot.

ref: https://canary.discord.com/channels/755868545279328417/1097569981761339473