### PR TITLE
build: move database dependencies to group

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN pip install poetry==1.5.1
 
 # export requirements after copying req files
 COPY pyproject.toml poetry.lock ./
-RUN poetry export --without-hashes > requirements.txt
+RUN poetry export --with=database --without-hashes > requirements.txt
 RUN pip uninstall poetry -y
 RUN pip install -Ur requirements.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN pip install poetry==1.5.1
 
 # export requirements after copying req files
 COPY pyproject.toml poetry.lock ./
-RUN poetry export --with=database --without-hashes > requirements.txt
+RUN poetry export --without-hashes > requirements.txt
 RUN pip uninstall poetry -y
 RUN pip install -Ur requirements.txt
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,8 @@ psutil = "^5.9.4"
 rapidfuzz = "^2.13.2"
 statsd = "^3.3.0"
 sentry-sdk = "^1.11.1"
-# database dependencies
+
+[tool.poetry.group.database.dependencies]
 alembic = "^1.10.2"
 asyncpg = "^0.27.0"
 SQLAlchemy = { version = "~=2.0.6", extras = ['asyncio'] }


### PR DESCRIPTION
I noticed that the pyproject.toml file had a 'database dependencies' comment, so this pull request moves it to its own group instead of it being under a the `main` group.