### PR TITLE
Revert "chore: disable dependabot for pip"

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,3 +8,11 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "00:00"
+      timezone: "Etc/GMT+5"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
This reverts commit 13c5ec5e8d5ce9796dab34dfd9cf4e908ccb473c.