### PR TITLE
ci: don't send discord embed on PR workflow event

### DIFF
--- a/.github/workflows/lint_test_build.yaml
+++ b/.github/workflows/lint_test_build.yaml
@@ -147,31 +147,3 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/monty-python:${{ steps.sha_tag.outputs.tag }}
           build-args: |
             git_sha=${{ github.sha }}
-
-
-  artifact:
-    name: Generate Artifact
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      # Prepare the Pull Request Payload artifact. If this fails, we
-      # we fail silently using the `continue-on-error` option. It's
-      # nice if this succeeds, but if it fails for any reason, it
-      # does not mean that our lint-test checks failed.
-      - name: Prepare Pull Request Payload artifact
-        id: prepare-artifact
-        if: always() && github.event_name == 'pull_request'
-        continue-on-error: true
-        run: cat $GITHUB_EVENT_PATH | jq '.pull_request' > pull_request_payload.json
-
-      # This only makes sense if the previous step succeeded. To
-      # get the original outcome of the previous step before the
-      # `continue-on-error` conclusion is applied, we use the
-      # `.outcome` value. This step also fails silently.
-      - name: Upload a Build Artifact
-        if: always() && steps.prepare-artifact.outcome == 'success'
-        continue-on-error: true
-        uses: actions/upload-artifact@v4
-        with:
-          name: pull-request-payload
-          path: pull_request_payload.json

--- a/.github/workflows/lint_test_build.yaml
+++ b/.github/workflows/lint_test_build.yaml
@@ -147,3 +147,31 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/monty-python:${{ steps.sha_tag.outputs.tag }}
           build-args: |
             git_sha=${{ github.sha }}
+
+
+  artifact:
+    name: Generate Artifact
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      # Prepare the Pull Request Payload artifact. If this fails, we
+      # we fail silently using the `continue-on-error` option. It's
+      # nice if this succeeds, but if it fails for any reason, it
+      # does not mean that our lint-test checks failed.
+      - name: Prepare Pull Request Payload artifact
+        id: prepare-artifact
+        if: always() && github.event_name == 'pull_request'
+        continue-on-error: true
+        run: cat $GITHUB_EVENT_PATH | jq '.pull_request' > pull_request_payload.json
+
+      # This only makes sense if the previous step succeeded. To
+      # get the original outcome of the previous step before the
+      # `continue-on-error` conclusion is applied, we use the
+      # `.outcome` value. This step also fails silently.
+      - name: Upload a Build Artifact
+        if: always() && steps.prepare-artifact.outcome == 'success'
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: pull-request-payload
+          path: pull_request_payload.json

--- a/.github/workflows/status_embed.yaml
+++ b/.github/workflows/status_embed.yaml
@@ -14,28 +14,11 @@ permissions:
 
 jobs:
   status_embed:
-    name:  Send Status Embed to Discord
+    name: Send Status Embed to Discord
+    if: github.event.workflow_run.event != 'pull_request'
     runs-on: ubuntu-latest
 
     steps:
-      # Process the artifact uploaded in the `pull_request`-triggered workflow:
-      - name: Get Pull Request Information
-        id: pr_info
-        if: github.event.workflow_run.event == 'pull_request'
-        run: |
-          curl -s -H "Authorization: token $GITHUB_TOKEN" ${{ github.event.workflow_run.artifacts_url }} > artifacts.json
-          DOWNLOAD_URL=$(cat artifacts.json | jq -r '.artifacts[] | select(.name == "pull-request-payload") | .archive_download_url')
-          [ -z "$DOWNLOAD_URL" ] && exit 1
-          curl -sSL -H "Authorization: token $GITHUB_TOKEN" -o pull_request_payload.zip $DOWNLOAD_URL || exit 2
-          unzip -p pull_request_payload.zip > pull_request_payload.json
-          [ -s pull_request_payload.json ] || exit 3
-          echo "pr_author_login=$(jq -r '.user.login // empty' pull_request_payload.json)" >> $GITHUB_OUTPUT
-          echo "pr_number=$(jq -r '.number // empty' pull_request_payload.json)" >> $GITHUB_OUTPUT
-          echo "pr_title=$(jq -r '.title // empty' pull_request_payload.json)" >> $GITHUB_OUTPUT
-          echo "pr_source=$(jq -r '.head.label // empty' pull_request_payload.json)" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       # Send an informational status embed to Discord instead of the
       # standard embeds that Discord sends. This embed will contain
       # more information and we can fine tune when we actually want
@@ -57,9 +40,3 @@ jobs:
           repository:  ${{ github.repository }}
           ref: ${{ github.ref }}
           sha: ${{ github.event.workflow_run.head_sha }}
-
-          # Now we can use the information extracted in the previous step:
-          pr_author_login: ${{ steps.pr_info.outputs.pr_author_login }}
-          pr_number: ${{ steps.pr_info.outputs.pr_number }}
-          pr_title: ${{ steps.pr_info.outputs.pr_title }}
-          pr_source: ${{ steps.pr_info.outputs.pr_source }}

--- a/.github/workflows/status_embed.yaml
+++ b/.github/workflows/status_embed.yaml
@@ -15,10 +15,28 @@ permissions:
 jobs:
   status_embed:
     name: Send Status Embed to Discord
-    if: github.event.workflow_run.event != 'pull_request'
     runs-on: ubuntu-latest
+    if: ${{ !endsWith(github.actor, "[bot]") }}
 
     steps:
+      # Process the artifact uploaded in the `pull_request`-triggered workflow:
+      - name: Get Pull Request Information
+        id: pr_info
+        if: github.event.workflow_run.event == 'pull_request'
+        run: |
+          curl -s -H "Authorization: token $GITHUB_TOKEN" ${{ github.event.workflow_run.artifacts_url }} > artifacts.json
+          DOWNLOAD_URL=$(cat artifacts.json | jq -r '.artifacts[] | select(.name == "pull-request-payload") | .archive_download_url')
+          [ -z "$DOWNLOAD_URL" ] && exit 1
+          curl -sSL -H "Authorization: token $GITHUB_TOKEN" -o pull_request_payload.zip $DOWNLOAD_URL || exit 2
+          unzip -p pull_request_payload.zip > pull_request_payload.json
+          [ -s pull_request_payload.json ] || exit 3
+          echo "pr_author_login=$(jq -r '.user.login // empty' pull_request_payload.json)" >> $GITHUB_OUTPUT
+          echo "pr_number=$(jq -r '.number // empty' pull_request_payload.json)" >> $GITHUB_OUTPUT
+          echo "pr_title=$(jq -r '.title // empty' pull_request_payload.json)" >> $GITHUB_OUTPUT
+          echo "pr_source=$(jq -r '.head.label // empty' pull_request_payload.json)" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       # Send an informational status embed to Discord instead of the
       # standard embeds that Discord sends. This embed will contain
       # more information and we can fine tune when we actually want
@@ -40,3 +58,9 @@ jobs:
           repository:  ${{ github.repository }}
           ref: ${{ github.ref }}
           sha: ${{ github.event.workflow_run.head_sha }}
+
+          # Now we can use the information extracted in the previous step:
+          pr_author_login: ${{ steps.pr_info.outputs.pr_author_login }}
+          pr_number: ${{ steps.pr_info.outputs.pr_number }}
+          pr_title: ${{ steps.pr_info.outputs.pr_title }}
+          pr_source: ${{ steps.pr_info.outputs.pr_source }}


### PR DESCRIPTION
This removes the workflow steps for sending an embed through a Discord webhook for PR checks, because god is it spammy. i think dependabot is slowly making me lose my sanity.
Workflow events/checks from branches in the repo are still sent to the webhook; this just removes the PR part.

disclaimer, untested c: