### PR TITLE
fix: set up logging before importing other modules

### DIFF
--- a/monty/__init__.py
+++ b/monty/__init__.py
@@ -18,6 +18,9 @@ from disnake.ext import commands
 from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.integrations.redis import RedisIntegration
 
+####################
+# NOTE: do not import any other modules before the `log.setup()` call
+####################
 from monty import log
 
 

--- a/monty/__init__.py
+++ b/monty/__init__.py
@@ -18,7 +18,7 @@ from disnake.ext import commands
 from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.integrations.redis import RedisIntegration
 
-from monty import log, monkey_patches
+from monty import log
 
 
 sentry_logging = LoggingIntegration(
@@ -36,6 +36,10 @@ sentry_sdk.init(
 )
 
 log.setup()
+
+
+from monty import monkey_patches  # noqa: E402  # we need to set up logging before importing anything else
+
 
 # On Windows, the selector event loop is required for aiodns.
 if os.name == "nt":


### PR DESCRIPTION
Paginators are currently broken, see https://canary.discord.com/channels/755868545279328417/952320005251411978/1286694032529031279
```py
Traceback (most recent call last):
  File "/workspaces/monty-python/.venv/lib/python3.11/site-packages/disnake/ext/commands/core.py", line 173, in wrapped
    ret = await coro(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/monty-python/monty/exts/info/utils.py", line 98, in snowflake
    await LinePaginator.paginate(lines, ctx=ctx, embed=embed, max_lines=5, max_size=1000)
  File "/workspaces/monty-python/monty/utils/pagination.py", line 184, in paginate
    log.trace(f"Added line to paginator: '{line}'")
    ^^^^^^^^^
AttributeError: 'Logger' object has no attribute 'trace'
```

This was caused by the fact that `monkey_patches` now imports `monty.utils`, which imports `monty.utils.pagination`, which ends up calling `get_logger` before `log.setup()` was called in the main module.