### PR TITLE
fix(markdown): improve handling of github issue references

### DIFF
--- a/monty/utils/markdown.py
+++ b/monty/utils/markdown.py
@@ -184,8 +184,8 @@ class DiscordRenderer(mistune.renderers.BaseRenderer):
         return ""
 
     def block_text(self, text: str) -> str:
-        """Return text in lists as-is."""
-        return text
+        """Handle text in lists like normal text."""
+        return self.text(text)
 
     def block_code(self, code: str, info: str = None) -> str:
         """Put the code in a codeblock."""

--- a/monty/utils/markdown.py
+++ b/monty/utils/markdown.py
@@ -183,8 +183,8 @@ class DiscordRenderer(mistune.renderers.BaseRenderer):
         return ""
 
     def block_text(self, text: str) -> str:
-        """Handle text in lists like normal text."""
-        return self.text(text)
+        """Return text in lists as-is."""
+        return text
 
     def block_code(self, code: str, info: str = None) -> str:
         """Put the code in a codeblock."""

--- a/monty/utils/markdown.py
+++ b/monty/utils/markdown.py
@@ -23,7 +23,8 @@ CODE_BLOCK_RE = re.compile(
     re.DOTALL | re.MULTILINE,
 )
 
-GH_ISSUE_RE = re.compile(r"\s(?:GH-|#)(\d+)")
+# references should be preceded by a non-word character (or element start)
+GH_ISSUE_RE = re.compile(r"(?:^|(?<=\W))(?:#|GH-)(\d+)\b", re.I)
 
 
 def remove_codeblocks(content: str) -> str:


### PR DESCRIPTION
The old regex didn't account for all valid cases:
- a reference may be preceded by any non-word character (or line start), not just whitespace
- it should have a word boundary at the end
- a lowercase `gh-` is also valid

| old regex | new regex |
|:------:|:------:|
| ![image](https://github.com/user-attachments/assets/1c15dd47-2c66-4aa0-acff-0bb09e389a19) | ![image](https://github.com/user-attachments/assets/dd5f1f21-5648-46c9-9ead-c5c7752b6a1c) | 

Note that these only work as shown with a fix that's part of #333, which fixes displaying links in lists.
There are a couple other valid issue reference formats as evident in those screenshots, which I might implement some other time.