### PR TITLE
fix(ci): make status embed workflow run again

### DIFF
--- a/.github/workflows/status_embed.yaml
+++ b/.github/workflows/status_embed.yaml
@@ -16,7 +16,7 @@ jobs:
   status_embed:
     name: Send Status Embed to Discord
     runs-on: ubuntu-latest
-    if: ${{ !endsWith(github.actor, "[bot]") }}
+    if: ${{ !endsWith(github.actor, '[bot]') }}
 
     steps:
       # Process the artifact uploaded in the `pull_request`-triggered workflow:


### PR DESCRIPTION
apparently double quotes aren't valid here, while single quotes [are](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idif)

i love yaml

followup to #311