### PR TITLE
feat: slightly adjust ratelimit command output

### DIFF
--- a/monty/exts/info/github_info.py
+++ b/monty/exts/info/github_info.py
@@ -789,14 +789,15 @@ class GithubInfo(commands.Cog, name="GitHub Information", slash_command_attrs={"
         if refresh:
             await self._fetch_and_update_ratelimits()
 
+        use_inline = len(monty.utils.services.GITHUB_RATELIMITS) <= 18  # 25 fields, 3 per line, 1 for the seperator.
         for i, (resource_name, rate_limit) in enumerate(monty.utils.services.GITHUB_RATELIMITS.items()):
             embed_value = ""
             for name, value in attrs.asdict(rate_limit).items():
                 embed_value += f"**`{name}`**: {value}\n"
-            embed.add_field(name=resource_name, value=embed_value, inline=True)
+            embed.add_field(name=resource_name, value=embed_value, inline=use_inline)
 
             # add a "newline" after every 3 fields
-            if i % 3 == 2:
+            if use_inline and i % 3 == 2:
                 embed.add_field("", "", inline=False)
 
         if len(embed.fields) == 0 or random.randint(0, 3) == 0:

--- a/monty/exts/info/github_info.py
+++ b/monty/exts/info/github_info.py
@@ -789,11 +789,15 @@ class GithubInfo(commands.Cog, name="GitHub Information", slash_command_attrs={"
         if refresh:
             await self._fetch_and_update_ratelimits()
 
-        for resource_name, rate_limit in monty.utils.services.GITHUB_RATELIMITS.items():
+        for i, (resource_name, rate_limit) in enumerate(monty.utils.services.GITHUB_RATELIMITS.items()):
             embed_value = ""
             for name, value in attrs.asdict(rate_limit).items():
                 embed_value += f"**`{name}`**: {value}\n"
-            embed.add_field(name=resource_name, value=embed_value, inline=False)
+            embed.add_field(name=resource_name, value=embed_value, inline=True)
+
+            # add a "newline" after every 3 fields
+            if i % 3 == 2:
+                embed.add_field("", "", inline=False)
 
         if len(embed.fields) == 0 or not (random.randint(0, 7) % 4):
             embed.set_footer(text="GitHub moment.")

--- a/monty/exts/info/github_info.py
+++ b/monty/exts/info/github_info.py
@@ -799,7 +799,7 @@ class GithubInfo(commands.Cog, name="GitHub Information", slash_command_attrs={"
             if i % 3 == 2:
                 embed.add_field("", "", inline=False)
 
-        if len(embed.fields) == 0 or not (random.randint(0, 7) % 4):
+        if len(embed.fields) == 0 or random.randint(0, 3) == 0:
             embed.set_footer(text="GitHub moment.")
         await ctx.send(
             embed=embed,


### PR DESCRIPTION
This removes the resource name from the model (since it's already present in the dict key), and groups the command output into 3 columns instead of 1, resulting in a much more readable output. Also works fine on mobile.

| looooooong embed | not so long embed |
|:------:|:------:|
| ![image](https://github.com/user-attachments/assets/33fc9242-0975-471a-b81d-b1342272dbd6) | ![image](https://github.com/user-attachments/assets/300f79a6-73a8-40d5-96eb-bea0150fe642) | 