### PR TITLE
fix: apply proxy to (almost) all requests

### DIFF
--- a/monty/__main__.py
+++ b/monty/__main__.py
@@ -94,11 +94,6 @@ async def main() -> None:
         sync_commands_debug=True,
         sync_on_cog_actions=True,
     )
-
-    kwargs = {}
-    if constants.Client.proxy is not None:
-        kwargs["proxy"] = constants.Client.proxy
-
     bot = Monty(
         redis_session=redis_session,
         command_prefix=constants.Client.default_command_prefix,
@@ -106,7 +101,7 @@ async def main() -> None:
         allowed_mentions=disnake.AllowedMentions(everyone=False),
         intents=_intents,
         command_sync_flags=command_sync_flags,
-        **kwargs,
+        proxy=constants.Client.proxy,
     )
 
     try:

--- a/monty/bot.py
+++ b/monty/bot.py
@@ -212,7 +212,7 @@ class Monty(commands.Bot):
             return aiohttp.ClientRequest  # default
 
         proxy_url = yarl.URL(proxy)
-        verify_ssl = not (proxy and proxy.startswith("http://"))
+        verify_ssl = not proxy.startswith("http://")
 
         class ProxyClientRequest(aiohttp.ClientRequest):
             def __init__(self, *args: Any, **kwargs: Any):

--- a/monty/bot.py
+++ b/monty/bot.py
@@ -202,7 +202,7 @@ class Monty(commands.Bot):
         return aiohttp.TCPConnector(
             resolver=aiohttp.AsyncResolver(),
             family=socket.AF_INET,
-            verify_ssl=not bool(proxy and proxy.startswith("http://")),
+            ssl=not (proxy and proxy.startswith("http://")),
         )
 
     async def get_self_invite_perms(self) -> disnake.Permissions:

--- a/monty/exts/info/github_info.py
+++ b/monty/exts/info/github_info.py
@@ -208,7 +208,14 @@ class GithubInfo(commands.Cog, name="GitHub Information", slash_command_attrs={"
         self.bot = bot
 
         transport = AIOHTTPTransport(
-            url="https://api.github.com/graphql", timeout=20, headers=GITHUB_REQUEST_HEADERS, ssl=True
+            url="https://api.github.com/graphql",
+            timeout=20,
+            headers=GITHUB_REQUEST_HEADERS,
+            ssl=True,
+            client_session_args={
+                # used for applying proxy settings
+                "request_class": bot.http_request_class,
+            },
         )
 
         self.gql = gql.Client(transport=transport, fetch_schema_from_transport=True)


### PR DESCRIPTION
Right now, the `BOT_PROXY_URL` env variable only applies to `bot.http_session`. This PR expands this to more requests:
- All requests to the Discord API by the underlying disnake client (except interaction responses due to https://github.com/DisnakeDev/disnake/issues/261)
- GraphQL requests to GitHub

The GraphQL one was a bit annoying, since graphql-python doesn't have a proxy parameter itself. It does, however, support passing arbitrary kwargs to the created `aiohttp.ClientSession`, which we can use to set a proxy by providing a custom `request_class=`.