### PR TITLE
fix: use `redis.aclose()`

### DIFF
--- a/monty/bot.py
+++ b/monty/bot.py
@@ -373,12 +373,13 @@ class Monty(commands.Bot):
 
         if self.http_session:
             await self.http_session.close()
-
         if self.db_engine:
             await self.db_engine.dispose()
 
         if self.redis_session:
             await self.redis_session.aclose(close_connection_pool=True)
+
+        await asyncio.sleep(0.6)
 
     def load_extensions(self) -> None:
         """Load all extensions as released by walk_extensions()."""

--- a/monty/bot.py
+++ b/monty/bot.py
@@ -378,7 +378,7 @@ class Monty(commands.Bot):
             await self.db_engine.dispose()
 
         if self.redis_session:
-            await self.redis_session.close(close_connection_pool=True)
+            await self.redis_session.aclose(close_connection_pool=True)
 
     def load_extensions(self) -> None:
         """Load all extensions as released by walk_extensions()."""


### PR DESCRIPTION
With `DeprecationWarning`s turned on, prints a warning after the update in #306 when the bot stops:
```py
/workspaces/monty-python/monty/bot.py:381: DeprecationWarning: Call to deprecated close. (Use aclose() instead) -- Deprecated since version 5.0.1.
  await self.redis_session.close(close_connection_pool=True)
```