### PR TITLE
lint: enable `flake8-logging-format` ruff ruleset

### DIFF
--- a/monty/bot.py
+++ b/monty/bot.py
@@ -63,7 +63,7 @@ class Monty(commands.Bot):
     def __init__(self, redis_session: redis.asyncio.Redis, proxy: str = None, **kwargs) -> None:
         if TEST_GUILDS:
             kwargs["test_guilds"] = TEST_GUILDS
-            log.warn("registering as test_guilds")
+            log.warning("registering as test_guilds")
         super().__init__(**kwargs)
 
         self.redis_session = redis_session

--- a/monty/exts/backend/error_handler.py
+++ b/monty/exts/backend/error_handler.py
@@ -210,7 +210,7 @@ class ErrorHandler(
 
         elif isinstance(error, (commands.CommandInvokeError, commands.ConversionError)):
             if isinstance(error.original, disnake.Forbidden):
-                logger.warn(f"Permissions error occurred in {ctx.command}.")
+                logger.warning(f"Permissions error occurred in {ctx.command}.")
                 await self.handle_bot_missing_perms(ctx, error.original)
                 should_respond = False
             else:

--- a/monty/exts/info/docs/_cog.py
+++ b/monty/exts/info/docs/_cog.py
@@ -874,7 +874,7 @@ class DocCog(commands.Cog, name="Documentation", slash_command_attrs={"dm_permis
             session.add(package)
             await session.commit()
 
-        log.info(f"User @{ctx.author} ({ctx.author.id}) added a new documentation package:\n" + repr(package))
+        log.info(f"User @{ctx.author} ({ctx.author.id}) added a new documentation package:\n{package!r}")
 
         self.update_single(package, inventory_dict)
         await ctx.send(

--- a/monty/exts/info/github_info.py
+++ b/monty/exts/info/github_info.py
@@ -1030,7 +1030,7 @@ class GithubInfo(commands.Cog, name="GitHub Information", slash_command_attrs={"
                         },
                     )
                 except (TransportError, TransportQueryError) as e:
-                    log.warn("encountered error fetching discussion comment: %s", e)
+                    log.warning("encountered error fetching discussion comment: %s", e)
                     continue
 
                 comment = json_data["node"]
@@ -1059,7 +1059,7 @@ class GithubInfo(commands.Cog, name="GitHub Information", slash_command_attrs={"
 
                 comment = await self.fetch_data(endpoint, as_text=False)  # type: ignore
                 if "message" in comment:
-                    log.warn("encountered error fetching %s: %s", endpoint, comment)
+                    log.warning("encountered error fetching %s: %s", endpoint, comment)
                     continue
 
             # assert the url was not tampered with

--- a/monty/exts/info/pypi.py
+++ b/monty/exts/info/pypi.py
@@ -126,7 +126,7 @@ class PyPI(commands.Cog, slash_command_attrs={"dm_permission": False}):
                 try:
                     top_packages.extend([pack["project"] for pack in json["rows"][:300]])
                 except Exception:
-                    log.error("Encountered an error with setting the top packages", exc_info=True)
+                    log.exception("Encountered an error with setting the top packages")
 
         return all_packages, top_packages
 

--- a/monty/utils/caching.py
+++ b/monty/utils/caching.py
@@ -140,7 +140,7 @@ def redis_cache(
 
                 if value is not UNSET:
                     if constants.Client.debug:
-                        cache_logger.info("Cache hit on {key}".format(key=key))
+                        cache_logger.info("Cache hit on %s", key)
 
                     return value
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ select = [
     "C", # flake8-comprehensions
     "D", # flake-docstrings
     "DTZ", # flake8-datetimez
+    "G", # flake8-logging-format
     "Q", # flake8-quotes
     "T201", "T203" # flake8-print
 ]
@@ -110,6 +111,7 @@ ignore = [
 
     # temporarily disabled
     "C901", # mccabe
+    "G004", # Logging statement uses f-string
     "S101", # Use of `assert` detected
     "S110", # try-except-pass
     "S311", # pseduo-random generators, random is used everywhere for random choices.


### PR DESCRIPTION
`logging.Logger.warn` has been deprecated since Python 3.3.