### PR TITLE
fix(github): don't ping-reply automatic issue links

### DIFF
--- a/monty/exts/info/github_info.py
+++ b/monty/exts/info/github_info.py
@@ -1259,7 +1259,11 @@ class GithubInfo(commands.Cog, name="GitHub Information", slash_command_attrs={"
         if isinstance(message, disnake.ApplicationCommandInteraction):
             await message.send(embed=embed, components=components)
         else:
-            response = await message.reply(embed=embed, components=components)
+            response = await message.reply(
+                embed=embed,
+                components=components,
+                allowed_mentions=disnake.AllowedMentions(replied_user=False),
+            )
             self.autolink_cache.set(message.id, (response, issues))
 
     @commands.Cog.listener("on_message_edit")


### PR DESCRIPTION
This is purely a visual change; comment auto-linking already doesn't do this[^1], I noticed while testing #404 that issue auto-linking would ping-reply, starting with c42c81e29fb311efd11c93f58bfc0f7f839b9e35.

[^1]: https://github.com/onerandomusername/monty-python/blob/6a640edb071a7ce0ac798e0739363ce91df43f83/monty/exts/info/github_info.py#L1121