### PR TITLE
feat: support autolinking `github.com/orgs/<org>/discussions/<id>`

### DIFF
--- a/monty/constants.py
+++ b/monty/constants.py
@@ -227,6 +227,7 @@ class Stats(NamedTuple):
 
 class Tokens(NamedTuple):
     github = environ.get("GITHUB_TOKEN")
+    github_secondary = environ.get("GITHUB_TOKEN_SECONDARY")
 
 
 class RedisConfig(NamedTuple):

--- a/monty/utils/services.py
+++ b/monty/utils/services.py
@@ -23,8 +23,12 @@ GITHUB_REQUEST_HEADERS = {
     "Accept": "application/vnd.github.v3+json",
     "X-GitHub-Api-Version": "2022-11-28",
 }
+GITHUB_REQUEST_HEADERS_SECONDARY = GITHUB_REQUEST_HEADERS.copy()
+
 if constants.Tokens.github:
     GITHUB_REQUEST_HEADERS["Authorization"] = f"token {constants.Tokens.github}"
+if constants.Tokens.github_secondary:
+    GITHUB_REQUEST_HEADERS_SECONDARY["Authorization"] = f"token {constants.Tokens.github_secondary}"
 
 
 @define()


### PR DESCRIPTION
Adds support for expanding links to organization discussions[^1].

Draft until I properly fix the `issue url x does not match comment url y` thing, but it already works just fine and can be reviewed~


[^1]: This uses a separate GitHub token for undisclosed reasons. I kinda just felt like it. Really. I wouldn't recommend merging them and using this token for everything else too, just in case it behaves differently.