### PR TITLE
fix(codesnippets): use `?per_page=100` when fetching branches/tags

### DIFF
--- a/monty/exts/info/codesnippets.py
+++ b/monty/exts/info/codesnippets.py
@@ -144,12 +144,12 @@ class CodeSnippets(commands.Cog, name="Code Snippets"):
         """Fetches a snippet from a GitHub repo."""
         # Search the GitHub API for the specified branch
         branches = await self._fetch_response(
-            f"https://api.github.com/repos/{repo}/branches",
+            f"https://api.github.com/repos/{repo}/branches?per_page=100",
             "json",
             headers=GITHUB_REQUEST_HEADERS,
         )
         tags = await self._fetch_response(
-            f"https://api.github.com/repos/{repo}/tags", "json", headers=GITHUB_REQUEST_HEADERS
+            f"https://api.github.com/repos/{repo}/tags?per_page=100", "json", headers=GITHUB_REQUEST_HEADERS
         )
         refs = branches + tags
         ref, encoded_file_path = self._find_ref(path, refs)


### PR DESCRIPTION
Auto-linking of code snippets fetches branches and tags in an attempt to partition the `blob/things/stuff/path/file.py` string into a known branch and file path, but previously only fetched the first 30, which is the default.
This changes it to 100, the max before we'd have to start paginating. It's not perfect, but at least more reliable than before c: