### PR TITLE
docs: fix typo in autodoc command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -204,7 +204,7 @@ Running the autodoc session should automatically update these files, if there
 were any changes.
 
 ```sh
-uv run nox -s autodoc`
+uv run nox -s autodoc
 ```
 
 ### Building the documentation


### PR DESCRIPTION
Fixed a typo where an additional grave character was added after the autodoc command in `CONTRIBUTING.md`.