### PR TITLE
deps: update setup-uv for faster windows & bump default python

### DIFF
--- a/.github/actions/setup-env/action.yaml
+++ b/.github/actions/setup-env/action.yaml
@@ -6,7 +6,7 @@ inputs:
   python-version:
     description: The python version to install
     required: false
-    default: '3.9'
+    default: '3.10'
 outputs:
   python-version:
     description: The python version that was installed.


### PR DESCRIPTION
Could let Dependabot make this PR. But I noticed that the default python version is now invalid. Even though it shouldn't matter. Wanted to update it while I was at it. 