### PR TITLE
fix: use monochrome unicode variation selector for emoji to avoid resync

### DIFF
--- a/monty/config/models.py
+++ b/monty/config/models.py
@@ -43,7 +43,7 @@ class Category(enum.Enum):
     General = CategoryMetadata(
         name="General",
         description="General bot configuration options.",
-        emoji="⚙️",
+        emoji="⚙",
         button=CategoryButtonMetadata(
             label="Edit General",
         ),


### PR DESCRIPTION
Discord apparently strips (some/most?) unicode control characters in strings, including variation selector 16 (U+FE0F), which means commands will resync every time on startup, as `"⚙️" != "⚙"` (\u2699\ufe0f vs \u2699). As far as I can tell, we'll just have to concede to Discord here.